### PR TITLE
perf(vue): do not cache vue resolution replacements, better loop

### DIFF
--- a/examples/with-build/App.vue
+++ b/examples/with-build/App.vue
@@ -1,8 +1,10 @@
 <script lang="ts" setup>
+import Counter from './components/Counter.vue';
 import { ref } from 'vue';
 const message = ref('Hello, Vue 3 with TypeScript!');
 </script>
 
 <template>
   <h1>{{ message }}</h1>
+  <Counter />
 </template>

--- a/examples/with-build/components/Counter.vue
+++ b/examples/with-build/components/Counter.vue
@@ -1,0 +1,11 @@
+<script lang="ts" setup>
+import { ref } from 'vue';
+const count = ref(0);
+</script>
+
+<template>
+  <div>
+    <p>Count: {{ count }}</p>
+    <button @click="count++">Increment</button>
+  </div>
+</template>


### PR DESCRIPTION
Adding entire Vue source files into a Map is perhaps not the greatest idea, there are very few files that run through the replacer and as soon as Bun supports modifying the build config at runtime in the dev server, this could be removed anyway.