### PR TITLE
fix(vue): normalize path separators in onResolve and onLoad handlers for Windows

### DIFF
--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -34,3 +34,18 @@ test('fails on empty', async () => {
     expect.stringContaining('[vue-plugin:error] Errors parsing')
   );
 })
+
+test.if(process.platform === 'win32')('it builds with Windows backslashes', async () => {
+  const Basic = (await import('./fixtures/Basic.vue')).default;
+  // Replace forward slashes with backslashes to simulate Windows paths
+  const windowsPath = Basic.replace(/\//g, '\\');
+
+  const output = await Bun.build({
+    // @ts-expect-error
+    entrypoints: [windowsPath],
+    plugins: [vuePlugin()],
+  })
+
+  expect(output.success).toBe(true);
+  expect(output.outputs[0]!.size).toBeGreaterThan(0);
+})


### PR DESCRIPTION
Fix #4 by normalizing `\` paths to `/` to support Windows target.